### PR TITLE
Use cache_key_with_version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 - ...
 
+## [2.3.1] - 2021-07-14
+- Use `#cache_key_with_version` instead of `#cache_key`
+
 ## [2.3.0] - 2021-06-05
-- optimize the cache performance by batch load the cache
-- support proc on cache_options namespace
-- cache_options namespace merged into cache key
-- temp disable fieldset support, expect to bring back that in next version
+- Optimize the cache performance by batch load the cache
+- Support proc on cache_options namespace
+- Add cache_options namespace merged into cache key
+- Temporarily disable fieldset support, expect to bring back that in next version
 
 ## [2.2.0] - 2021-03-11
 

--- a/lib/fast_jsonapi/serialization_core.rb
+++ b/lib/fast_jsonapi/serialization_core.rb
@@ -66,10 +66,15 @@ module FastJsonapi
         FastJsonapi.call_proc(meta_to_serialize, record, params)
       end
 
-      # move the namespace to be part of cache_key
+      # Move the namespace to be part of cache_key
       # since ActiveSupport doesn't support multi read with different namespaces
+      #
+      # Use #cache_key_with_version instead of #cache_key because we don't
+      # pass AR objects as keys to cache store and thus we can't leverage the
+      # built-in cache versioning from rails 6. This is a good opportunity for
+      # future improvement.
       def generate_cache_key(record, namespace)
-        "#{namespace}-#{record.cache_key}"
+        "#{namespace}-#{record.cache_key_with_version}"
       end
 
       def record_hash(record, fieldset, includes_list, params = {})

--- a/lib/jsonapi/serializer/version.rb
+++ b/lib/jsonapi/serializer/version.rb
@@ -1,5 +1,5 @@
 module JSONAPI
   module Serializer
-    VERSION = '2.3.0'.freeze
+    VERSION = '2.3.1'.freeze
   end
 end


### PR DESCRIPTION
With Rails 6 cache-versioning enabled, #cache_key will no longer return timestamp and that breaks this implementation as we don't send AR objects to cache stores as keys. This PR changes to use cache_key_with_version instead so we'll always get timestamp in the key.